### PR TITLE
Fix temp files being read before writing finished

### DIFF
--- a/lib/ILdfManifest.ts
+++ b/lib/ILdfManifest.ts
@@ -15,8 +15,8 @@ export async function ldfManifestFromResource(testCaseHandlers: {[uri: string]: 
                                               options: IFetchOptions, resource: Resource, startPort?: number):
   Promise<IManifest> {
   // The factory will allow each ITestCase to setup a mocking server if needed
-  let factory: LdfResponseMockerFactory = new LdfResponseMockerFactory(options, startPort);
-  let res: IManifest = {
+  const factory: LdfResponseMockerFactory = new LdfResponseMockerFactory(options, startPort);
+  const res: IManifest = {
     comment: resource.property.comment ? resource.property.comment.value : null,
     label: resource.property.label ? resource.property.label.value : null,
     specifications: resource.property.specifications ? await Util.promiseValues<IManifest>(

--- a/lib/LdfUtil.ts
+++ b/lib/LdfUtil.ts
@@ -34,14 +34,7 @@ export class LdfUtil {
       const filename: string = iri.split('/').slice(-1)[0];
       const file = fs.createWriteStream(Path.join(folder, filename));
       const { body } = await Util.fetchCached(iri, options);
-
-      body.on('data', (data: any) => {
-        file.write(data);
-      });
-      body.on('end', () => {
-        file.end();
-        resolve(filename);
-      });
+      body.pipe(file).on('finish', () => resolve(filename));
     });
   }
 


### PR DESCRIPTION
Pretty sure this fixes comunica/comunica#537. I've been running the tests non-stop for half an hour whereas usually I get the error after less than a minute.

The problem was probably that the data was written to the temporary file, but the reading of that file started without waiting on the writestream to end, causing a race condition.

Also one test kept failing locally so I hope it works here because it should not be related to this change :P (the "should error when the port is in use" test).