### PR TITLE
Fixed the -m option not working

### DIFF
--- a/bin/Runner.ts
+++ b/bin/Runner.ts
@@ -29,7 +29,7 @@ ${Util.withColor('Options:', Util.COLOR_YELLOW)}
   -t    regex for test IRIs to run
   -i    JSON string with custom options that need to be passed to the engine
   -d    time out duration for test cases (in milliseconds, default 30000)
-  -m    URL to local path mapping (e.g. 'https://w3c.github.io/json-ld-api/|/path/to/folder/')
+  -m    URL to local path mapping (e.g. 'https://w3c.github.io/json-ld-api/~/path/to/folder/')
   -r    The port number on which the mocking servers will start spawning (10000 by default)
   -v    Time (ms) to wait before stopping the server after each completed test
 `);
@@ -39,7 +39,7 @@ ${Util.withColor('Options:', Util.COLOR_YELLOW)}
 // Enable caching if needed
 let cachePath: string = null;
 if (args.c) {
-  if(! args.c.endsWith('/')){
+  if(args.c !== true && ! args.c.endsWith('/')){
     console.error(Util.withColor(`Please give a correct caching path. The path '${args.c}' is invalid. Did you forget a trailing slash?`, Util.COLOR_YELLOW));
     process.exit(1);
   }

--- a/lib/LdfTestSuiteRunner.ts
+++ b/lib/LdfTestSuiteRunner.ts
@@ -11,16 +11,13 @@ export class LdfTestSuiteRunner extends TestSuiteRunner {
    * Run the manifest with the given URL.
    * @param {string} manifestUrl The URL of a manifest.
    * @param handler The handler to run the tests with.
-   * @param {string} cachePath The base directory to cache files in. If falsy, then no cache will be used.
-   * @param {string} specification An optional specification to scope the manifest tests by.
-   * @param {RegExp} testRegex An optional regex to filter test IRIs by.
-   * @param {any} injectArguments An optional set of arguments to pass to the handler.
+   * @param config configurations.
    * @return {Promise<ITestResult[]>} A promise resolving to an array of test results.
    */
   public async runManifest(manifestUrl: string, handler: any, config: ILdfTestSuiteConfig): Promise<ITestResult[]> {
-    config.urlToFileMapping = <any> this.fromUrlToMappingString(config.urlToFileMapping);
+    const urlToFileMappings = this.fromUrlToMappingString(config.urlToFileMapping);
     const manifest: IManifest = await new LdfManifestLoader()
-      .from(manifestUrl, config);
+      .from(manifestUrl, { ...config, urlToFileMappings });
     const results: ITestResult[] = [];
 
     // Only run the tests for the given specification if one was defined.


### PR DESCRIPTION
Fixed an issue where there would be no output if there's no cache provided. (false)

Fixed part of an issue where the -m option doesn't work. I think the rest of the problem is not related to this repository, but to [rdf-test-suite.js](https://github.com/rubensworks/rdf-test-suite.js). (false, it was fully fixed)